### PR TITLE
Add all faker functions to MockObject

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "arrowParens": "always",
   "singleQuote": false,
   "semi": false,
   "trailingComma": "es5"

--- a/packages/graphql-mock-object/resolvers/index.js
+++ b/packages/graphql-mock-object/resolvers/index.js
@@ -229,7 +229,14 @@ export const MockObject = {
     return {}
   },
   name: () => ({}),
+  phone: () => ({}),
   String: fakerResolver("{{lorem.sentence}}"),
+}
+
+export const MockPhone = {
+  phoneFormats: fakerResolver("{{phone.phoneFormats}}"),
+  phoneNumber: fakerResolver("{{phone.phoneNumber}}"),
+  phoneNumberFormat: fakerResolver("{{phone.phoneNumberFormat}}"),
 }
 
 export const Query = {
@@ -249,5 +256,6 @@ export const resolvers = {
   MockLorem,
   MockName,
   MockObject,
+  MockPhone,
   Query,
 }

--- a/packages/graphql-mock-object/resolvers/index.js
+++ b/packages/graphql-mock-object/resolvers/index.js
@@ -31,11 +31,23 @@ export const MockAddress = {
   zipCode: fakerResolver("{{address.zipCode}}"),
 }
 
+export const MockCommerce = {
+  color: fakerResolver("{{commerce.color}}"),
+  department: fakerResolver("{{commerce.department}}"),
+  price: fakerResolver("{{commerce.price}}"),
+  product: fakerResolver("{{commerce.product}}"),
+  productAdjective: fakerResolver("{{commerce.productAdjective}}"),
+  productName: fakerResolver("{{commerce.productName}}"),
+  productMaterial: fakerResolver("{{commerce.productMaterial}}"),
+}
+
 export const MockObject = {
   address(parent, args) {
     return {}
   },
-
+  commerce(parent, args) {
+    return {}
+  },
   Boolean: fakerResolver("{{random.boolean}}"),
   Float: fakerResolver("0.{{random.number}}"),
   ID: fakerResolver("{{random.number}}"),
@@ -61,6 +73,7 @@ export const Query = {
 
 export const resolvers = {
   MockAddress,
+  MockCommerce,
   MockObject,
   Query,
 }

--- a/packages/graphql-mock-object/resolvers/index.js
+++ b/packages/graphql-mock-object/resolvers/index.js
@@ -57,17 +57,19 @@ export const MockCompany = {
   },
 }
 
+export const MockDatabase = {
+  collation: fakerResolver("{{database.collation}}"),
+  column: fakerResolver("{{database.column}}"),
+  engine: fakerResolver("{{database.engine}}"),
+  type: fakerResolver("{{database.type}}"),
+}
+
 export const MockObject = {
-  address(parent, args) {
-    return {}
-  },
-  commerce(parent, args) {
-    return {}
-  },
-  company(parent, args) {
-    return {}
-  },
+  address: () => ({}),
   Boolean: fakerResolver("{{random.boolean}}"),
+  commerce: () => ({}),
+  company: () => ({}),
+  database: () => ({}),
   Float: fakerResolver("0.{{random.number}}"),
   ID: fakerResolver("{{random.number}}"),
   Int: fakerResolver("{{random.number}}"),
@@ -94,6 +96,7 @@ export const resolvers = {
   MockAddress,
   MockCommerce,
   MockCompany,
+  MockDatabase,
   MockObject,
   Query,
 }

--- a/packages/graphql-mock-object/resolvers/index.js
+++ b/packages/graphql-mock-object/resolvers/index.js
@@ -95,6 +95,15 @@ export const MockFinance = {
   transactionType: fakerResolver("{{finance.transactionType}}"),
 }
 
+export const MockHacker = {
+  abbreviation: fakerResolver("{{hacker.abbreviation}}"),
+  adjective: fakerResolver("{{hacker.adjective}}"),
+  ingverb: fakerResolver("{{hacker.ingverb}}"),
+  noun: fakerResolver("{{hacker.noun}}"),
+  phrase: fakerResolver("{{hacker.phrase}}"),
+  verb: fakerResolver("{{hacker.verb}}"),
+}
+
 export const MockObject = {
   address: () => ({}),
   Boolean: fakerResolver("{{random.boolean}}"),
@@ -104,6 +113,7 @@ export const MockObject = {
   date: () => ({}),
   finance: () => ({}),
   Float: fakerResolver("0.{{random.number}}"),
+  hacker: () => ({}),
   ID: fakerResolver("{{random.number}}"),
   Int: fakerResolver("{{random.number}}"),
   List(parent, args) {
@@ -132,6 +142,7 @@ export const resolvers = {
   MockDatabase,
   MockDate,
   MockFinance,
+  MockHacker,
   MockObject,
   Query,
 }

--- a/packages/graphql-mock-object/resolvers/index.js
+++ b/packages/graphql-mock-object/resolvers/index.js
@@ -14,54 +14,54 @@ const fakerResolver = (template) => (parent, args) => {
 
 // The resolvers
 export const MockAddress = {
-  city: fakerResolver("{{address.city}}"),
-  cityPrefix: fakerResolver("{{address.cityPrefix}}"),
-  country: fakerResolver("{{address.country}}"),
-  countryCode: fakerResolver("{{address.countryCode}}"),
-  county: fakerResolver("{{address.county}}"),
-  latitude: fakerResolver("{{address.latitude}}"),
-  longitude: fakerResolver("{{address.longitude}}"),
-  secondaryAddress: fakerResolver("{{address.secondaryAddress}}"),
-  state: fakerResolver("{{address.state}}"),
-  stateAbbr: fakerResolver("{{address.stateAbbr}}"),
-  streetAddress: fakerResolver("{{address.streetAddress}}"),
-  streetName: fakerResolver("{{address.streetName}}"),
-  streetPrefix: fakerResolver("{{address.streetPrefix}}"),
-  streetSuffix: fakerResolver("{{address.streetSuffix}}"),
-  zipCode: fakerResolver("{{address.zipCode}}"),
+  city: () => faker.address.city(),
+  cityPrefix: () => faker.address.cityPrefix(),
+  country: () => faker.address.country(),
+  countryCode: () => faker.address.countryCode(),
+  county: () => faker.address.county(),
+  latitude: () => faker.address.latitude(),
+  longitude: () => faker.address.longitude(),
+  secondaryAddress: () => faker.address.secondaryAddress(),
+  state: () => faker.address.state(),
+  stateAbbr: () => faker.address.stateAbbr(),
+  streetAddress: () => faker.address.streetAddress(),
+  streetName: () => faker.address.streetName(),
+  streetPrefix: () => faker.address.streetPrefix(),
+  streetSuffix: () => faker.address.streetSuffix(),
+  zipCode: () => faker.address.zipCode(),
 }
 
 export const MockCommerce = {
-  color: fakerResolver("{{commerce.color}}"),
-  department: fakerResolver("{{commerce.department}}"),
-  price: fakerResolver("{{commerce.price}}"),
-  product: fakerResolver("{{commerce.product}}"),
-  productAdjective: fakerResolver("{{commerce.productAdjective}}"),
-  productName: fakerResolver("{{commerce.productName}}"),
-  productMaterial: fakerResolver("{{commerce.productMaterial}}"),
+  color: () => faker.commerce.color(),
+  department: () => faker.commerce.department(),
+  price: () => faker.commerce.price(),
+  product: () => faker.commerce.product(),
+  productAdjective: () => faker.commerce.productAdjective(),
+  productName: () => faker.commerce.productName(),
+  productMaterial: () => faker.commerce.productMaterial(),
 }
 
 export const MockCompany = {
-  bs: fakerResolver("{{company.bs}}"),
-  bsAdjective: fakerResolver("{{company.bsAdjective}}"),
-  bsBuzz: fakerResolver("{{company.bsBuzz}}"),
-  bsNoun: fakerResolver("{{company.bsNoun}}"),
-  catchPhraseAdjective: fakerResolver("{{company.catchPhraseAdjective}}"),
-  catchPhraseDescriptor: fakerResolver("{{company.catchPhraseDescriptor}}"),
-  catchPhrase: fakerResolver("{{company.catchPhrase}}"),
-  catchPhraseNoun: fakerResolver("{{company.catchPhraseNoun}}"),
-  companyName: fakerResolver("{{company.companyName}}"),
-  companySuffix: fakerResolver("{{company.companySuffix}}"),
+  bs: () => faker.company.bs(),
+  bsAdjective: () => faker.company.bsAdjective(),
+  bsBuzz: () => faker.company.bsBuzz(),
+  bsNoun: () => faker.company.bsNoun(),
+  catchPhraseAdjective: () => faker.company.catchPhraseAdjective(),
+  catchPhraseDescriptor: () => faker.company.catchPhraseDescriptor(),
+  catchPhrase: () => faker.company.catchPhrase(),
+  catchPhraseNoun: () => faker.company.catchPhraseNoun(),
+  companyName: () => faker.company.companyName(),
+  companySuffix: () => faker.company.companySuffix(),
   suffixes(parent, args) {
     return faker.company.suffixes()
   },
 }
 
 export const MockDatabase = {
-  collation: fakerResolver("{{database.collation}}"),
-  column: fakerResolver("{{database.column}}"),
-  engine: fakerResolver("{{database.engine}}"),
-  type: fakerResolver("{{database.type}}"),
+  collation: () => faker.database.collation(),
+  column: () => faker.database.column(),
+  engine: () => faker.database.engine(),
+  type: () => faker.database.type(),
 }
 
 export const MockDate = {
@@ -71,37 +71,37 @@ export const MockDate = {
   future(parent, args) {
     return faker.date.future(args.years, args.refDate)
   },
-  month: fakerResolver("{{date.month}}"),
+  month: () => faker.date.month(),
   past(parent, args) {
     return faker.date.past(args.years, args.refDate)
   },
   recent(parent, args) {
     return faker.date.recent(args.days)
   },
-  weekday: fakerResolver("{{date.weekday}}"),
+  weekday: () => faker.date.weekday(),
 }
 
 export const MockFinance = {
-  account: fakerResolver("{{finance.account}}"),
-  accountName: fakerResolver("{{finance.accountName}}"),
-  amount: fakerResolver("{{finance.amount}}"),
-  bic: fakerResolver("{{finance.bic}}"),
-  bitcoinAddress: fakerResolver("{{finance.bitcoinAddress}}"),
-  currencyCode: fakerResolver("{{finance.currencyCode}}"),
-  currencyName: fakerResolver("{{finance.currencyName}}"),
-  currencySymbol: fakerResolver("{{finance.currencySymbol}}"),
-  iban: fakerResolver("{{finance.iban}}"),
-  mask: fakerResolver("{{finance.mask}}"),
-  transactionType: fakerResolver("{{finance.transactionType}}"),
+  account: () => faker.finance.account(),
+  accountName: () => faker.finance.accountName(),
+  amount: () => faker.finance.amount(),
+  bic: () => faker.finance.bic(),
+  bitcoinAddress: () => faker.finance.bitcoinAddress(),
+  currencyCode: () => faker.finance.currencyCode(),
+  currencyName: () => faker.finance.currencyName(),
+  currencySymbol: () => faker.finance.currencySymbol(),
+  iban: () => faker.finance.iban(),
+  mask: () => faker.finance.mask(),
+  transactionType: () => faker.finance.transactionType(),
 }
 
 export const MockHacker = {
-  abbreviation: fakerResolver("{{hacker.abbreviation}}"),
-  adjective: fakerResolver("{{hacker.adjective}}"),
-  ingverb: fakerResolver("{{hacker.ingverb}}"),
-  noun: fakerResolver("{{hacker.noun}}"),
-  phrase: fakerResolver("{{hacker.phrase}}"),
-  verb: fakerResolver("{{hacker.verb}}"),
+  abbreviation: () => faker.hacker.abbreviation(),
+  adjective: () => faker.hacker.adjective(),
+  ingverb: () => faker.hacker.ingverb(),
+  noun: () => faker.hacker.noun(),
+  phrase: () => faker.hacker.phrase(),
+  verb: () => faker.hacker.verb(),
 }
 
 export const MockImage = {
@@ -159,51 +159,51 @@ export const MockImage = {
 }
 
 export const MockInternet = {
-  avatar: fakerResolver("{{internet.avatar}}"),
-  color: fakerResolver("{{internet.color}}"),
-  domainName: fakerResolver("{{internet.domainName}}"),
-  domainSuffix: fakerResolver("{{internet.domainSuffix}}"),
-  domainWord: fakerResolver("{{internet.domainWord}}"),
-  email: fakerResolver("{{internet.email}}"),
-  exampleEmail: fakerResolver("{{internet.exampleEmail}}"),
-  ip: fakerResolver("{{internet.ip}}"),
-  ipv6: fakerResolver("{{internet.ipv6}}"),
-  mac: fakerResolver("{{internet.mac}}"),
-  password: fakerResolver("{{internet.password}}"),
-  protocol: fakerResolver("{{internet.protocol}}"),
-  url: fakerResolver("{{internet.url}}"),
-  userAgent: fakerResolver("{{internet.userAgent}}"),
-  userName: fakerResolver("{{internet.userName}}"),
+  avatar: () => faker.internet.avatar(),
+  color: () => faker.internet.color(),
+  domainName: () => faker.internet.domainName(),
+  domainSuffix: () => faker.internet.domainSuffix(),
+  domainWord: () => faker.internet.domainWord(),
+  email: () => faker.internet.email(),
+  exampleEmail: () => faker.internet.exampleEmail(),
+  ip: () => faker.internet.ip(),
+  ipv6: () => faker.internet.ipv6(),
+  mac: () => faker.internet.mac(),
+  password: () => faker.internet.password(),
+  protocol: () => faker.internet.protocol(),
+  url: () => faker.internet.url(),
+  userAgent: () => faker.internet.userAgent(),
+  userName: () => faker.internet.userName(),
 }
 
 export const MockLorem = {
-  lines: fakerResolver("{{lorem.lines}}"),
-  paragraph: fakerResolver("{{lorem.paragraph}}"),
-  paragraphs: fakerResolver("{{lorem.paragraphs}}"),
-  sentence: fakerResolver("{{lorem.sentence}}"),
-  sentences: fakerResolver("{{lorem.sentences}}"),
-  slug: fakerResolver("{{lorem.slug}}"),
-  text: fakerResolver("{{lorem.text}}"),
-  word: fakerResolver("{{lorem.word}}"),
-  words: fakerResolver("{{lorem.words}}"),
+  lines: () => faker.lorem.lines(),
+  paragraph: () => faker.lorem.paragraph(),
+  paragraphs: () => faker.lorem.paragraphs(),
+  sentence: () => faker.lorem.sentence(),
+  sentences: () => faker.lorem.sentences(),
+  slug: () => faker.lorem.slug(),
+  text: () => faker.lorem.text(),
+  word: () => faker.lorem.word(),
+  words: () => faker.lorem.words(),
 }
 
 export const MockName = {
-  findName: fakerResolver("{{name.findName}}"),
-  firstName: fakerResolver("{{name.firstName}}"),
-  jobArea: fakerResolver("{{name.jobArea}}"),
-  jobDescriptor: fakerResolver("{{name.jobDescriptor}}"),
-  jobTitle: fakerResolver("{{name.jobTitle}}"),
-  jobType: fakerResolver("{{name.jobType}}"),
-  lastName: fakerResolver("{{name.lastName}}"),
-  prefix: fakerResolver("{{name.prefix}}"),
-  suffix: fakerResolver("{{name.suffix}}"),
-  title: fakerResolver("{{name.title}}"),
+  findName: () => faker.name.findName(),
+  firstName: () => faker.name.firstName(),
+  jobArea: () => faker.name.jobArea(),
+  jobDescriptor: () => faker.name.jobDescriptor(),
+  jobTitle: () => faker.name.jobTitle(),
+  jobType: () => faker.name.jobType(),
+  lastName: () => faker.name.lastName(),
+  prefix: () => faker.name.prefix(),
+  suffix: () => faker.name.suffix(),
+  title: () => faker.name.title(),
 }
 
 export const MockObject = {
   address: () => ({}),
-  Boolean: fakerResolver("{{random.boolean}}"),
+  Boolean: () => faker.random.boolean(),
   commerce: () => ({}),
   company: () => ({}),
   database: () => ({}),
@@ -231,12 +231,26 @@ export const MockObject = {
   name: () => ({}),
   phone: () => ({}),
   String: fakerResolver("{{lorem.sentence}}"),
+  random: () => ({}),
 }
 
 export const MockPhone = {
-  phoneFormats: fakerResolver("{{phone.phoneFormats}}"),
-  phoneNumber: fakerResolver("{{phone.phoneNumber}}"),
-  phoneNumberFormat: fakerResolver("{{phone.phoneNumberFormat}}"),
+  phoneFormats: () => faker.phone.phoneFormats(),
+  phoneNumber: () => faker.phone.phoneNumber(),
+  phoneNumberFormat: () => faker.phone.phoneNumberFormat(),
+}
+
+export const MockRandom = {
+  alphaNumeric: () => faker.random.alphaNumeric(),
+  arrayElement: () => faker.random.arrayElement(),
+  boolean: () => faker.random.boolean(),
+  image: () => faker.random.image(),
+  locale: () => faker.random.locale(),
+  number: () => faker.random.number(),
+  objectElement: () => faker.random.objectElement(),
+  uuid: () => faker.random.uuid(),
+  word: () => faker.random.word(),
+  words: () => faker.random.words(),
 }
 
 export const Query = {
@@ -257,5 +271,6 @@ export const resolvers = {
   MockName,
   MockObject,
   MockPhone,
+  MockRandom,
   Query,
 }

--- a/packages/graphql-mock-object/resolvers/index.js
+++ b/packages/graphql-mock-object/resolvers/index.js
@@ -6,12 +6,6 @@ import { version } from "../package.json"
 // version change will yield different resultsl
 const majorVersion = parseInt(version.match(/\d+/g).shift(), 10) || 1
 
-const fakerResolver = (template) => (parent, args) => {
-  const { value = template } = args
-
-  return faker.fake(value)
-}
-
 // The resolvers
 export const MockAddress = {
   city: () => faker.address.city(),
@@ -209,11 +203,23 @@ export const MockObject = {
   database: () => ({}),
   date: () => ({}),
   finance: () => ({}),
-  Float: fakerResolver("0.{{random.number}}"),
+  Float(parent, args) {
+    const { template = "0.{{random.number}}" } = args
+
+    return faker.fake(template)
+  },
   hacker: () => ({}),
-  ID: fakerResolver("{{random.number}}"),
+  ID(parent, args) {
+    const { template = "{{random.number}}" } = args
+
+    return faker.fake(template)
+  },
   image: () => ({}),
-  Int: fakerResolver("{{random.number}}"),
+  Int(parent, args) {
+    const { template = "{{random.number}}" } = args
+
+    return faker.fake(template)
+  },
   internet: () => ({}),
   List(parent, args) {
     const { length } = args
@@ -230,7 +236,11 @@ export const MockObject = {
   },
   name: () => ({}),
   phone: () => ({}),
-  String: fakerResolver("{{lorem.sentence}}"),
+  String(parent, args) {
+    const { template = "{{lorem.sentence}}" } = args
+
+    return faker.fake(template)
+  },
   random: () => ({}),
 }
 

--- a/packages/graphql-mock-object/resolvers/index.js
+++ b/packages/graphql-mock-object/resolvers/index.js
@@ -64,12 +64,30 @@ export const MockDatabase = {
   type: fakerResolver("{{database.type}}"),
 }
 
+export const MockDate = {
+  between(parent, args) {
+    return faker.date.between(args.from, args.to)
+  },
+  future(parent, args) {
+    return faker.date.future(args.years, args.refDate)
+  },
+  month: fakerResolver("{{date.month}}"),
+  past(parent, args) {
+    return faker.date.past(args.years, args.refDate)
+  },
+  recent(parent, args) {
+    return faker.date.recent(args.days)
+  },
+  weekday: fakerResolver("{{date.weekday}}"),
+}
+
 export const MockObject = {
   address: () => ({}),
   Boolean: fakerResolver("{{random.boolean}}"),
   commerce: () => ({}),
   company: () => ({}),
   database: () => ({}),
+  date: () => ({}),
   Float: fakerResolver("0.{{random.number}}"),
   ID: fakerResolver("{{random.number}}"),
   Int: fakerResolver("{{random.number}}"),
@@ -97,6 +115,7 @@ export const resolvers = {
   MockCommerce,
   MockCompany,
   MockDatabase,
+  MockDate,
   MockObject,
   Query,
 }

--- a/packages/graphql-mock-object/resolvers/index.js
+++ b/packages/graphql-mock-object/resolvers/index.js
@@ -158,6 +158,24 @@ export const MockImage = {
   },
 }
 
+export const MockInternet = {
+  avatar: fakerResolver("{{internet.avatar}}"),
+  color: fakerResolver("{{internet.color}}"),
+  domainName: fakerResolver("{{internet.domainName}}"),
+  domainSuffix: fakerResolver("{{internet.domainSuffix}}"),
+  domainWord: fakerResolver("{{internet.domainWord}}"),
+  email: fakerResolver("{{internet.email}}"),
+  exampleEmail: fakerResolver("{{internet.exampleEmail}}"),
+  ip: fakerResolver("{{internet.ip}}"),
+  ipv6: fakerResolver("{{internet.ipv6}}"),
+  mac: fakerResolver("{{internet.mac}}"),
+  password: fakerResolver("{{internet.password}}"),
+  protocol: fakerResolver("{{internet.protocol}}"),
+  url: fakerResolver("{{internet.url}}"),
+  userAgent: fakerResolver("{{internet.userAgent}}"),
+  userName: fakerResolver("{{internet.userName}}"),
+}
+
 export const MockObject = {
   address: () => ({}),
   Boolean: fakerResolver("{{random.boolean}}"),
@@ -171,6 +189,7 @@ export const MockObject = {
   ID: fakerResolver("{{random.number}}"),
   image: () => ({}),
   Int: fakerResolver("{{random.number}}"),
+  internet: () => ({}),
   List(parent, args) {
     const { length } = args
 
@@ -199,6 +218,7 @@ export const resolvers = {
   MockFinance,
   MockHacker,
   MockImage,
+  MockInternet,
   MockObject,
   Query,
 }

--- a/packages/graphql-mock-object/resolvers/index.js
+++ b/packages/graphql-mock-object/resolvers/index.js
@@ -242,6 +242,7 @@ export const MockObject = {
     return faker.fake(template)
   },
   random: () => ({}),
+  system: () => ({}),
 }
 
 export const MockPhone = {
@@ -263,6 +264,17 @@ export const MockRandom = {
   words: () => faker.random.words(),
 }
 
+export const MockSystem = {
+  commonFileExt: () => faker.system.commonFileExt(),
+  commonFileName: () => faker.system.commonFileName(),
+  commonFileType: () => faker.system.commonFileType(),
+  fileExt: () => faker.system.fileExt(),
+  fileName: () => faker.system.fileName(),
+  fileType: () => faker.system.fileType(),
+  mimeType: () => faker.system.mimeType(),
+  semver: () => faker.system.semver(),
+}
+
 export const Query = {
   Mock: MockObject.Mock,
 }
@@ -282,5 +294,6 @@ export const resolvers = {
   MockObject,
   MockPhone,
   MockRandom,
+  MockSystem,
   Query,
 }

--- a/packages/graphql-mock-object/resolvers/index.js
+++ b/packages/graphql-mock-object/resolvers/index.js
@@ -6,7 +6,7 @@ import { version } from "../package.json"
 // version change will yield different resultsl
 const majorVersion = parseInt(version.match(/\d+/g).shift(), 10) || 1
 
-const fakerResolver = template => (parent, args) => {
+const fakerResolver = (template) => (parent, args) => {
   const { value = template } = args
 
   return faker.fake(value)
@@ -104,6 +104,60 @@ export const MockHacker = {
   verb: fakerResolver("{{hacker.verb}}"),
 }
 
+export const MockImage = {
+  abstract(parent, { width, height, randomize }) {
+    return faker.image.abstract(width, height, randomize)
+  },
+  animals(parent, { width, height, randomize }) {
+    return faker.image.animals(width, height, randomize)
+  },
+  avatar() {
+    return faker.image.avatar()
+  },
+  business(parent, { width, height, randomize }) {
+    return faker.image.business(width, height, randomize)
+  },
+  cats(parent, { width, height, randomize }) {
+    return faker.image.cats(width, height, randomize)
+  },
+  city(parent, { width, height, randomize }) {
+    return faker.image.city(width, height, randomize)
+  },
+  dataUri(parent, { width, height }) {
+    return faker.image.dataUri(width, height)
+  },
+  fashion(parent, { width, height, randomize }) {
+    return faker.image.fashion(width, height, randomize)
+  },
+  food(parent, { width, height, randomize }) {
+    return faker.image.food(width, height, randomize)
+  },
+  image(parent, { width, height, randomize }) {
+    return faker.image.image(width, height, randomize)
+  },
+  imageUrl(parent, { width, height, randomize }) {
+    return faker.image.imageUrl(width, height, randomize)
+  },
+  nature(parent, { width, height, randomize }) {
+    return faker.image.nature(width, height, randomize)
+  },
+  nightlife(parent, { width, height, randomize }) {
+    return faker.image.nightlife(width, height, randomize)
+  },
+  people(parent, { width, height, randomize }) {
+    return faker.image.people(width, height, randomize)
+  },
+  sports(parent, { width, height, randomize }) {
+    return faker.image.sports(width, height, randomize)
+  },
+  technics(parent, { width, height, randomize }) {
+    return faker.image.technics(width, height, randomize)
+  },
+  transport(parent, { width, height, randomize }) {
+    return faker.image.transport(width, height, randomize)
+  },
+}
+
 export const MockObject = {
   address: () => ({}),
   Boolean: fakerResolver("{{random.boolean}}"),
@@ -115,6 +169,7 @@ export const MockObject = {
   Float: fakerResolver("0.{{random.number}}"),
   hacker: () => ({}),
   ID: fakerResolver("{{random.number}}"),
+  image: () => ({}),
   Int: fakerResolver("{{random.number}}"),
   List(parent, args) {
     const { length } = args
@@ -143,6 +198,7 @@ export const resolvers = {
   MockDate,
   MockFinance,
   MockHacker,
+  MockImage,
   MockObject,
   Query,
 }

--- a/packages/graphql-mock-object/resolvers/index.js
+++ b/packages/graphql-mock-object/resolvers/index.js
@@ -176,6 +176,18 @@ export const MockInternet = {
   userName: fakerResolver("{{internet.userName}}"),
 }
 
+export const MockLorem = {
+  lines: fakerResolver("{{lorem.lines}}"),
+  paragraph: fakerResolver("{{lorem.paragraph}}"),
+  paragraphs: fakerResolver("{{lorem.paragraphs}}"),
+  sentence: fakerResolver("{{lorem.sentence}}"),
+  sentences: fakerResolver("{{lorem.sentences}}"),
+  slug: fakerResolver("{{lorem.slug}}"),
+  text: fakerResolver("{{lorem.text}}"),
+  word: fakerResolver("{{lorem.word}}"),
+  words: fakerResolver("{{lorem.words}}"),
+}
+
 export const MockObject = {
   address: () => ({}),
   Boolean: fakerResolver("{{random.boolean}}"),
@@ -195,6 +207,7 @@ export const MockObject = {
 
     return Array.from({ length }).map(() => ({}))
   },
+  lorem: () => ({}),
   Mock(parent, args) {
     const { seed = majorVersion } = args
 
@@ -219,6 +232,7 @@ export const resolvers = {
   MockHacker,
   MockImage,
   MockInternet,
+  MockLorem,
   MockObject,
   Query,
 }

--- a/packages/graphql-mock-object/resolvers/index.js
+++ b/packages/graphql-mock-object/resolvers/index.js
@@ -6,28 +6,40 @@ import { version } from "../package.json"
 // version change will yield different resultsl
 const majorVersion = parseInt(version.match(/\d+/g).shift(), 10) || 1
 
+const fakerResolver = template => (parent, args) => {
+  const { value = template } = args
+
+  return faker.fake(value)
+}
+
 // The resolvers
+export const MockAddress = {
+  city: fakerResolver("{{address.city}}"),
+  cityPrefix: fakerResolver("{{address.cityPrefix}}"),
+  country: fakerResolver("{{address.country}}"),
+  countryCode: fakerResolver("{{address.countryCode}}"),
+  county: fakerResolver("{{address.county}}"),
+  latitude: fakerResolver("{{address.latitude}}"),
+  longitude: fakerResolver("{{address.longitude}}"),
+  secondaryAddress: fakerResolver("{{address.secondaryAddress}}"),
+  state: fakerResolver("{{address.state}}"),
+  stateAbbr: fakerResolver("{{address.stateAbbr}}"),
+  streetAddress: fakerResolver("{{address.streetAddress}}"),
+  streetName: fakerResolver("{{address.streetName}}"),
+  streetPrefix: fakerResolver("{{address.streetPrefix}}"),
+  streetSuffix: fakerResolver("{{address.streetSuffix}}"),
+  zipCode: fakerResolver("{{address.zipCode}}"),
+}
+
 export const MockObject = {
-  Boolean(parent, args) {
-    const { value = "{{random.boolean}}" } = args
-
-    return faker.fake(value)
+  address(parent, args) {
+    return {}
   },
-  Float(parent, args) {
-    const { value = "0.{{random.number}}" } = args
 
-    return faker.fake(value)
-  },
-  ID(parent, args) {
-    const { value = "{{random.number}}" } = args
-
-    return faker.fake(value)
-  },
-  Int(parent, args) {
-    const { value = "{{random.number}}" } = args
-
-    return faker.fake(value)
-  },
+  Boolean: fakerResolver("{{random.boolean}}"),
+  Float: fakerResolver("0.{{random.number}}"),
+  ID: fakerResolver("{{random.number}}"),
+  Int: fakerResolver("{{random.number}}"),
   List(parent, args) {
     const { length } = args
 
@@ -40,11 +52,7 @@ export const MockObject = {
 
     return {}
   },
-  String(parent, args) {
-    const { value = "{{lorem.sentence}}" } = args
-
-    return faker.fake(value)
-  },
+  String: fakerResolver("{{lorem.sentence}}"),
 }
 
 export const Query = {
@@ -52,6 +60,7 @@ export const Query = {
 }
 
 export const resolvers = {
+  MockAddress,
   MockObject,
   Query,
 }

--- a/packages/graphql-mock-object/resolvers/index.js
+++ b/packages/graphql-mock-object/resolvers/index.js
@@ -188,6 +188,19 @@ export const MockLorem = {
   words: fakerResolver("{{lorem.words}}"),
 }
 
+export const MockName = {
+  findName: fakerResolver("{{name.findName}}"),
+  firstName: fakerResolver("{{name.firstName}}"),
+  jobArea: fakerResolver("{{name.jobArea}}"),
+  jobDescriptor: fakerResolver("{{name.jobDescriptor}}"),
+  jobTitle: fakerResolver("{{name.jobTitle}}"),
+  jobType: fakerResolver("{{name.jobType}}"),
+  lastName: fakerResolver("{{name.lastName}}"),
+  prefix: fakerResolver("{{name.prefix}}"),
+  suffix: fakerResolver("{{name.suffix}}"),
+  title: fakerResolver("{{name.title}}"),
+}
+
 export const MockObject = {
   address: () => ({}),
   Boolean: fakerResolver("{{random.boolean}}"),
@@ -215,6 +228,7 @@ export const MockObject = {
 
     return {}
   },
+  name: () => ({}),
   String: fakerResolver("{{lorem.sentence}}"),
 }
 
@@ -233,6 +247,7 @@ export const resolvers = {
   MockImage,
   MockInternet,
   MockLorem,
+  MockName,
   MockObject,
   Query,
 }

--- a/packages/graphql-mock-object/resolvers/index.js
+++ b/packages/graphql-mock-object/resolvers/index.js
@@ -81,6 +81,20 @@ export const MockDate = {
   weekday: fakerResolver("{{date.weekday}}"),
 }
 
+export const MockFinance = {
+  account: fakerResolver("{{finance.account}}"),
+  accountName: fakerResolver("{{finance.accountName}}"),
+  amount: fakerResolver("{{finance.amount}}"),
+  bic: fakerResolver("{{finance.bic}}"),
+  bitcoinAddress: fakerResolver("{{finance.bitcoinAddress}}"),
+  currencyCode: fakerResolver("{{finance.currencyCode}}"),
+  currencyName: fakerResolver("{{finance.currencyName}}"),
+  currencySymbol: fakerResolver("{{finance.currencySymbol}}"),
+  iban: fakerResolver("{{finance.iban}}"),
+  mask: fakerResolver("{{finance.mask}}"),
+  transactionType: fakerResolver("{{finance.transactionType}}"),
+}
+
 export const MockObject = {
   address: () => ({}),
   Boolean: fakerResolver("{{random.boolean}}"),
@@ -88,6 +102,7 @@ export const MockObject = {
   company: () => ({}),
   database: () => ({}),
   date: () => ({}),
+  finance: () => ({}),
   Float: fakerResolver("0.{{random.number}}"),
   ID: fakerResolver("{{random.number}}"),
   Int: fakerResolver("{{random.number}}"),
@@ -116,6 +131,7 @@ export const resolvers = {
   MockCompany,
   MockDatabase,
   MockDate,
+  MockFinance,
   MockObject,
   Query,
 }

--- a/packages/graphql-mock-object/resolvers/index.js
+++ b/packages/graphql-mock-object/resolvers/index.js
@@ -41,11 +41,30 @@ export const MockCommerce = {
   productMaterial: fakerResolver("{{commerce.productMaterial}}"),
 }
 
+export const MockCompany = {
+  bs: fakerResolver("{{company.bs}}"),
+  bsAdjective: fakerResolver("{{company.bsAdjective}}"),
+  bsBuzz: fakerResolver("{{company.bsBuzz}}"),
+  bsNoun: fakerResolver("{{company.bsNoun}}"),
+  catchPhraseAdjective: fakerResolver("{{company.catchPhraseAdjective}}"),
+  catchPhraseDescriptor: fakerResolver("{{company.catchPhraseDescriptor}}"),
+  catchPhrase: fakerResolver("{{company.catchPhrase}}"),
+  catchPhraseNoun: fakerResolver("{{company.catchPhraseNoun}}"),
+  companyName: fakerResolver("{{company.companyName}}"),
+  companySuffix: fakerResolver("{{company.companySuffix}}"),
+  suffixes(parent, args) {
+    return faker.company.suffixes()
+  },
+}
+
 export const MockObject = {
   address(parent, args) {
     return {}
   },
   commerce(parent, args) {
+    return {}
+  },
+  company(parent, args) {
     return {}
   },
   Boolean: fakerResolver("{{random.boolean}}"),
@@ -74,6 +93,7 @@ export const Query = {
 export const resolvers = {
   MockAddress,
   MockCommerce,
+  MockCompany,
   MockObject,
   Query,
 }

--- a/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
+++ b/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
@@ -69,6 +69,14 @@ Object {
         },
       },
       Object {
+        "args": Array [],
+        "description": "",
+        "name": "hacker",
+        "type": Object {
+          "name": null,
+        },
+      },
+      Object {
         "args": Array [
           Object {
             "defaultValue": null,
@@ -243,6 +251,14 @@ Object {
       "iban": "DE30845851030092005075",
       "mask": "4952",
       "transactionType": "deposit",
+    },
+    "hacker": Object {
+      "abbreviation": "JSON",
+      "adjective": "primary",
+      "ingverb": "compressing",
+      "noun": "microchip",
+      "phrase": "We need to synthesize the mobile GB bandwidth!",
+      "verb": "hack",
     },
   },
 }

--- a/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
+++ b/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
@@ -107,6 +107,14 @@ Object {
         },
       },
       Object {
+        "args": Array [],
+        "description": "",
+        "name": "internet",
+        "type": Object {
+          "name": null,
+        },
+      },
+      Object {
         "args": Array [
           Object {
             "defaultValue": "0",
@@ -286,6 +294,23 @@ Object {
       "sports": "http://lorempixel.com/640/480/sports",
       "technics": "http://lorempixel.com/640/480/technics",
       "transport": "http://lorempixel.com/640/480/transport",
+    },
+    "internet": Object {
+      "avatar": "https://s3.amazonaws.com/uifaces/faces/twitter/sgaurav_baghel/128.jpg",
+      "color": "#180b7a",
+      "domainName": "malvina.net",
+      "domainSuffix": "biz",
+      "domainWord": "kamryn",
+      "email": "Melany42@yahoo.com",
+      "exampleEmail": "Reese_Smitham@example.net",
+      "ip": "225.122.204.215",
+      "ipv6": "5bca:eeca:45e8:83d3:3b3c:ffcd:3871:872e",
+      "mac": "4c:47:e7:83:92:51",
+      "password": "ZuH94f8vNpBJTOr",
+      "protocol": "https",
+      "url": "http://kamryn.net",
+      "userAgent": "Mozilla/5.0 (Windows; U; Windows NT 6.3) AppleWebKit/538.0.0 (KHTML, like Gecko) Chrome/29.0.817.0 Safari/538.0.0",
+      "userName": "Rodolfo99",
     },
   },
 }

--- a/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
+++ b/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
@@ -167,6 +167,14 @@ Object {
         },
       },
       Object {
+        "args": Array [],
+        "description": "",
+        "name": "phone",
+        "type": Object {
+          "name": null,
+        },
+      },
+      Object {
         "args": Array [
           Object {
             "defaultValue": null,
@@ -354,6 +362,11 @@ Ea rerum rerum. Nemo quasi veniam beatae numquam ut. Architecto consequuntur sit
       "prefix": "Dr.",
       "suffix": "DVM",
       "title": "International Usability Liaison",
+    },
+    "phone": Object {
+      "phoneFormats": "(###) ###-#### x###",
+      "phoneNumber": "1-786-649-8318 x840",
+      "phoneNumberFormat": "887-614-7684",
     },
   },
 }

--- a/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
+++ b/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
@@ -49,7 +49,15 @@ Object {
         "description": "",
         "name": "date",
         "type": Object {
-          "name": "MockDate",
+          "name": null,
+        },
+      },
+      Object {
+        "args": Array [],
+        "description": "",
+        "name": "finance",
+        "type": Object {
+          "name": null,
         },
       },
       Object {
@@ -222,6 +230,19 @@ Object {
       "past": "Wed May 30 2018 16:03:32 GMT-0700 (PDT)",
       "recent": "Wed May 30 2018 06:59:12 GMT-0700 (PDT)",
       "weekday": "Tuesday",
+    },
+    "finance": Object {
+      "account": 4675730,
+      "accountName": "Savings Account",
+      "amount": 315.77,
+      "bic": "OMTEMQH1",
+      "bitcoinAddress": "1NUNLVATADG27R72IU3OHGDDPIQG",
+      "currencyCode": "SAR",
+      "currencyName": "Trinidad and Tobago Dollar",
+      "currencySymbol": "﷼",
+      "iban": "DE30845851030092005075",
+      "mask": "4952",
+      "transactionType": "deposit",
     },
   },
 }

--- a/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
+++ b/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
@@ -93,6 +93,14 @@ Object {
       Object {
         "args": Array [],
         "description": "",
+        "name": "image",
+        "type": Object {
+          "name": null,
+        },
+      },
+      Object {
+        "args": Array [],
+        "description": "",
         "name": "Int",
         "type": Object {
           "name": null,
@@ -259,6 +267,25 @@ Object {
       "noun": "microchip",
       "phrase": "We need to synthesize the mobile GB bandwidth!",
       "verb": "hack",
+    },
+    "image": Object {
+      "abstract": "http://lorempixel.com/640/480/abstract",
+      "animals": "http://lorempixel.com/640/480/animals",
+      "avatar": "https://s3.amazonaws.com/uifaces/faces/twitter/juanmamartinez/128.jpg",
+      "business": "http://lorempixel.com/640/480/business",
+      "cats": "http://lorempixel.com/640/480/cats",
+      "city": "http://lorempixel.com/640/480/city",
+      "dataUri": "data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20version%3D%221.1%22%20baseProfile%3D%22full%22%20width%3D%22undefined%22%20height%3D%22undefined%22%3E%20%3Crect%20width%3D%22100%25%22%20height%3D%22100%25%22%20fill%3D%22grey%22%2F%3E%20%20%3Ctext%20x%3D%220%22%20y%3D%2220%22%20font-size%3D%2220%22%20text-anchor%3D%22start%22%20fill%3D%22white%22%3Eundefinedxundefined%3C%2Ftext%3E%20%3C%2Fsvg%3E",
+      "fashion": "http://lorempixel.com/640/480/fashion",
+      "food": "http://lorempixel.com/640/480/food",
+      "image": "http://lorempixel.com/640/480/fashion",
+      "imageUrl": "http://lorempixel.com/640/480",
+      "nature": "http://lorempixel.com/640/480/nature",
+      "nightlife": "http://lorempixel.com/640/480/nightlife",
+      "people": "http://lorempixel.com/640/480/people",
+      "sports": "http://lorempixel.com/640/480/sports",
+      "technics": "http://lorempixel.com/640/480/technics",
+      "transport": "http://lorempixel.com/640/480/transport",
     },
   },
 }

--- a/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
+++ b/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
@@ -15,6 +15,14 @@ Object {
       Object {
         "args": Array [],
         "description": "",
+        "name": "Boolean",
+        "type": Object {
+          "name": null,
+        },
+      },
+      Object {
+        "args": Array [],
+        "description": "",
         "name": "commerce",
         "type": Object {
           "name": null,
@@ -31,7 +39,7 @@ Object {
       Object {
         "args": Array [],
         "description": "",
-        "name": "Boolean",
+        "name": "database",
         "type": Object {
           "name": null,
         },
@@ -192,6 +200,12 @@ Object {
         "LLC",
         "Group",
       ],
+    },
+    "database": Object {
+      "collation": "cp1250_general_ci",
+      "column": "title",
+      "engine": "BLACKHOLE",
+      "type": "timestamp",
     },
   },
 }

--- a/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
+++ b/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
@@ -15,6 +15,14 @@ Object {
       Object {
         "args": Array [],
         "description": "",
+        "name": "commerce",
+        "type": Object {
+          "name": null,
+        },
+      },
+      Object {
+        "args": Array [],
+        "description": "",
         "name": "Boolean",
         "type": Object {
           "name": null,
@@ -149,6 +157,15 @@ Object {
       "streetPrefix": "b",
       "streetSuffix": "Ranch",
       "zipCode": "59075",
+    },
+    "commerce": Object {
+      "color": "silver",
+      "department": "Computers",
+      "price": 402,
+      "product": "Shirt",
+      "productAdjective": "Awesome",
+      "productMaterial": "Rubber",
+      "productName": "Gorgeous Plastic Chicken",
     },
   },
 }

--- a/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
+++ b/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
@@ -47,6 +47,14 @@ Object {
       Object {
         "args": Array [],
         "description": "",
+        "name": "date",
+        "type": Object {
+          "name": "MockDate",
+        },
+      },
+      Object {
+        "args": Array [],
+        "description": "",
         "name": "Float",
         "type": Object {
           "name": null,
@@ -206,6 +214,14 @@ Object {
       "column": "title",
       "engine": "BLACKHOLE",
       "type": "timestamp",
+    },
+    "date": Object {
+      "between": "Mon Jan 01 2018 00:00:00 GMT-0800 (PST)",
+      "future": "Tue Oct 23 2018 07:13:11 GMT-0700 (PDT)",
+      "month": "November",
+      "past": "Wed May 30 2018 16:03:32 GMT-0700 (PDT)",
+      "recent": "Wed May 30 2018 06:59:12 GMT-0700 (PDT)",
+      "weekday": "Tuesday",
     },
   },
 }

--- a/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
+++ b/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
@@ -153,6 +153,14 @@ Object {
       Object {
         "args": Array [],
         "description": "",
+        "name": "name",
+        "type": Object {
+          "name": null,
+        },
+      },
+      Object {
+        "args": Array [],
+        "description": "",
         "name": "Null",
         "type": Object {
           "name": "String",
@@ -334,6 +342,18 @@ Ea rerum rerum. Nemo quasi veniam beatae numquam ut. Architecto consequuntur sit
       "text": "Provident ratione dolor cumque assumenda.",
       "word": "similique",
       "words": "accusantium laborum et",
+    },
+    "name": Object {
+      "findName": "Mr. Haylee McCullough",
+      "firstName": "Barney",
+      "jobArea": "Functionality",
+      "jobDescriptor": "Global",
+      "jobTitle": "International Data Associate",
+      "jobType": "Associate",
+      "lastName": "Greenholt",
+      "prefix": "Dr.",
+      "suffix": "DVM",
+      "title": "International Usability Liaison",
     },
   },
 }

--- a/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
+++ b/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
@@ -175,6 +175,14 @@ Object {
         },
       },
       Object {
+        "args": Array [],
+        "description": "",
+        "name": "random",
+        "type": Object {
+          "name": null,
+        },
+      },
+      Object {
         "args": Array [
           Object {
             "defaultValue": null,
@@ -367,6 +375,18 @@ Ea rerum rerum. Nemo quasi veniam beatae numquam ut. Architecto consequuntur sit
       "phoneFormats": "(###) ###-#### x###",
       "phoneNumber": "1-786-649-8318 x840",
       "phoneNumberFormat": "887-614-7684",
+    },
+    "random": Object {
+      "alphaNumeric": "m",
+      "arrayElement": "c",
+      "boolean": false,
+      "image": "http://lorempixel.com/640/480/animals",
+      "locale": "en_BORK",
+      "number": 50815,
+      "objectElement": "car",
+      "uuid": "d0e03d4d-e052-40ab-a6bb-c71866e4ce3a",
+      "word": "Seamless",
+      "words": "Legacy Inverse Principal",
     },
   },
 }

--- a/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
+++ b/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
@@ -196,6 +196,14 @@ Object {
           "name": null,
         },
       },
+      Object {
+        "args": Array [],
+        "description": "",
+        "name": "system",
+        "type": Object {
+          "name": null,
+        },
+      },
     ],
     "inputFields": null,
   },
@@ -387,6 +395,16 @@ Ea rerum rerum. Nemo quasi veniam beatae numquam ut. Architecto consequuntur sit
       "uuid": "d0e03d4d-e052-40ab-a6bb-c71866e4ce3a",
       "word": "Seamless",
       "words": "Legacy Inverse Principal",
+    },
+    "system": Object {
+      "commonFileExt": "m2v",
+      "commonFileName": "awesome_granite_computer_png.gif",
+      "commonFileType": "application",
+      "fileExt": "hvp",
+      "fileName": "fresh_generic_rubber_cheese.sxm",
+      "fileType": "application",
+      "mimeType": "application/x-gca-compressed",
+      "semver": "2.7.6",
     },
   },
 }

--- a/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
+++ b/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
@@ -129,6 +129,14 @@ Object {
         },
       },
       Object {
+        "args": Array [],
+        "description": "",
+        "name": "lorem",
+        "type": Object {
+          "name": null,
+        },
+      },
+      Object {
         "args": Array [
           Object {
             "defaultValue": null,
@@ -309,8 +317,23 @@ Object {
       "password": "ZuH94f8vNpBJTOr",
       "protocol": "https",
       "url": "http://kamryn.net",
-      "userAgent": "Mozilla/5.0 (Windows; U; Windows NT 6.3) AppleWebKit/538.0.0 (KHTML, like Gecko) Chrome/29.0.817.0 Safari/538.0.0",
       "userName": "Rodolfo99",
+    },
+    "lorem": Object {
+      "lines": "Eligendi rem saepe impedit.
+Laboriosam et optio et placeat.",
+      "paragraph": "Quod pariatur nesciunt vitae optio nemo voluptas natus qui. Ea explicabo est voluptate eos ut ipsam est quam enim. Voluptas sequi dolores aut nihil quibusdam soluta ut fuga consequatur. Quia nesciunt labore qui eum corporis delectus odit cumque quis.",
+      "paragraphs": "Quis labore fugiat optio officiis accusantium sunt non. Commodi fugiat et pariatur. Ipsam id minima incidunt et dignissimos ut facilis. Dolor quo autem.
+ 
+Est voluptate incidunt odit delectus odio. At nisi ut hic quisquam cumque velit voluptas eos. Voluptatem illo modi. Ex corporis dolor sint ducimus sequi voluptatum reiciendis. Quas consequatur eum voluptatem architecto et deleniti.
+ 
+Ea rerum rerum. Nemo quasi veniam beatae numquam ut. Architecto consequuntur sit asperiores iusto et. Et qui reiciendis dolorum exercitationem quis. Dolorum in nesciunt temporibus ad et. Deserunt sequi consequuntur modi doloremque et incidunt deleniti perferendis.",
+      "sentence": "Ad doloremque earum.",
+      "sentences": "Neque architecto soluta ad quibusdam. In nihil eligendi qui reprehenderit et quae sit odio maxime. Consequatur mollitia omnis dolores autem. Harum vel omnis voluptatem.",
+      "slug": "quidem-velit-expedita",
+      "text": "Provident ratione dolor cumque assumenda.",
+      "word": "similique",
+      "words": "accusantium laborum et",
     },
   },
 }

--- a/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
+++ b/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
@@ -7,6 +7,14 @@ Object {
       Object {
         "args": Array [],
         "description": "",
+        "name": "address",
+        "type": Object {
+          "name": null,
+        },
+      },
+      Object {
+        "args": Array [],
+        "description": "",
         "name": "Boolean",
         "type": Object {
           "name": null,
@@ -67,7 +75,7 @@ Object {
         "description": "",
         "name": "Mock",
         "type": Object {
-          "name": "MockObject",
+          "name": null,
         },
       },
       Object {
@@ -118,6 +126,30 @@ Object {
     },
     "Null": null,
     "String": "Impedit voluptas nostrum.",
+  },
+}
+`;
+
+exports[`typeDefs MockObject should support faker.js 1`] = `
+Object {
+  "Mock": Object {
+    "address": Object {
+      "city": "Antonechester",
+      "cityPrefix": "Lake",
+      "country": "Finland",
+      "countryCode": "BQ",
+      "county": "Borders",
+      "latitude": 12.476,
+      "longitude": 141.4609,
+      "secondaryAddress": "Apt. 801",
+      "state": "Arizona",
+      "stateAbbr": "HI",
+      "streetAddress": "00460 Klein Crossroad",
+      "streetName": "Gottlieb Ports",
+      "streetPrefix": "b",
+      "streetSuffix": "Ranch",
+      "zipCode": "59075",
+    },
   },
 }
 `;

--- a/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
+++ b/packages/graphql-mock-object/typeDefs/__snapshots__/index.spec.js.snap
@@ -23,6 +23,14 @@ Object {
       Object {
         "args": Array [],
         "description": "",
+        "name": "company",
+        "type": Object {
+          "name": null,
+        },
+      },
+      Object {
+        "args": Array [],
+        "description": "",
         "name": "Boolean",
         "type": Object {
           "name": null,
@@ -164,8 +172,26 @@ Object {
       "price": 402,
       "product": "Shirt",
       "productAdjective": "Awesome",
-      "productMaterial": "Rubber",
-      "productName": "Gorgeous Plastic Chicken",
+      "productMaterial": "Plastic",
+      "productName": "Incredible Metal Soap",
+    },
+    "company": Object {
+      "bs": "magnetic morph platforms",
+      "bsAdjective": "bleeding-edge",
+      "bsBuzz": "deliver",
+      "bsNoun": "deliverables",
+      "catchPhrase": "Front-line demand-driven contingency",
+      "catchPhraseAdjective": "Seamless",
+      "catchPhraseDescriptor": "secondary",
+      "catchPhraseNoun": "success",
+      "companyName": "Raynor - Weber",
+      "companySuffix": "Inc",
+      "suffixes": Array [
+        "Inc",
+        "and Sons",
+        "LLC",
+        "Group",
+      ],
     },
   },
 }

--- a/packages/graphql-mock-object/typeDefs/index.js
+++ b/packages/graphql-mock-object/typeDefs/index.js
@@ -29,10 +29,28 @@ export const MockCommerce = `
     productMaterial: String!
   }
 `
+
+export const MockCompany = `
+  type MockCompany {
+    bs: String!
+    bsAdjective: String!
+    bsBuzz: String!
+    bsNoun: String!
+    catchPhraseAdjective: String!
+    catchPhraseDescriptor: String!
+    catchPhrase: String!
+    catchPhraseNoun: String!
+    companyName: String!
+    companySuffix: String!
+    suffixes: [String!]!
+  }
+`
+
 export const MockObject = `
   type MockObject {
     address: MockAddress!
     commerce: MockCommerce!
+    company: MockCompany!
     Boolean: Boolean!
     Float: Float!
     ID(value: String): ID!
@@ -50,4 +68,10 @@ export const Query = `
   }
 `
 
-export const typeDefs = [MockAddress, MockCommerce, MockObject, Query]
+export const typeDefs = [
+  MockAddress,
+  MockCommerce,
+  MockCompany,
+  MockObject,
+  Query,
+]

--- a/packages/graphql-mock-object/typeDefs/index.js
+++ b/packages/graphql-mock-object/typeDefs/index.js
@@ -66,6 +66,22 @@ export const MockDate = `
   }
 `
 
+export const MockFinance = `
+  type MockFinance {
+    account: Int!
+    accountName: String!
+    amount: Float!
+    bic: String!
+    bitcoinAddress: String!
+    currencyCode: String!
+    currencyName: String!
+    currencySymbol: String!
+    iban: String!
+    mask: String!
+    transactionType: String!
+  }
+`
+
 export const MockObject = `
   type MockObject {
     address: MockAddress!
@@ -73,7 +89,8 @@ export const MockObject = `
     commerce: MockCommerce!
     company: MockCompany!
     database: MockDatabase!
-    date: MockDate
+    date: MockDate!
+    finance: MockFinance!
     Float: Float!
     ID(value: String): ID!
     Int: Int!
@@ -96,6 +113,7 @@ export const typeDefs = [
   MockCompany,
   MockDatabase,
   MockDate,
+  MockFinance,
   MockObject,
   Query,
 ]

--- a/packages/graphql-mock-object/typeDefs/index.js
+++ b/packages/graphql-mock-object/typeDefs/index.js
@@ -135,6 +135,20 @@ export const MockInternet = `
   }
 `
 
+export const MockLorem = `
+  type MockLorem {
+    lines: String!
+    paragraph: String!
+    paragraphs: String!
+    sentence: String!
+    sentences: String!
+    slug: String!
+    text: String!
+    word: String!
+    words: String!
+  }
+`
+
 export const MockObject = `
   type MockObject {
     address: MockAddress!
@@ -151,6 +165,7 @@ export const MockObject = `
     Int: Int!
     internet: MockInternet!
     List(length: Int = 0): [MockObject]!
+    lorem: MockLorem!
     Mock(seed: Int): MockObject!
     Null: String
     String(value: String): String!
@@ -173,6 +188,7 @@ export const typeDefs = [
   MockHacker,
   MockImage,
   MockInternet,
+  MockLorem,
   MockObject,
   Query,
 ]

--- a/packages/graphql-mock-object/typeDefs/index.js
+++ b/packages/graphql-mock-object/typeDefs/index.js
@@ -187,6 +187,7 @@ export const MockObject = `
     phone: MockPhone!
     random: MockRandom!
     String(value: String): String!
+    system: MockSystem!
   }
 `
 
@@ -213,6 +214,23 @@ export const MockRandom = `
   }
 `
 
+export const MockSystem = `
+  type MockSystem {
+    commonFileExt: String!
+    commonFileName: String!
+    commonFileType: String!
+    # ! Not yet implemented
+    # directoryPath: String!
+    fileExt: String!
+    fileName: String!
+    # ! Not yet implemented
+    # filePath: String!
+    fileType: String!
+    mimeType: String!
+    semver: String!
+  }
+`
+
 export const Query = `
   type Query {
     Mock(seed: Int): MockObject
@@ -234,5 +252,6 @@ export const typeDefs = [
   MockObject,
   MockPhone,
   MockRandom,
+  MockSystem,
   Query,
 ]

--- a/packages/graphql-mock-object/typeDefs/index.js
+++ b/packages/graphql-mock-object/typeDefs/index.js
@@ -82,6 +82,17 @@ export const MockFinance = `
   }
 `
 
+export const MockHacker = `
+  type MockHacker {
+    abbreviation: String!
+    adjective: String!
+    ingverb: String!
+    noun: String!
+    phrase: String!
+    verb: String!
+  }
+`
+
 export const MockObject = `
   type MockObject {
     address: MockAddress!
@@ -92,6 +103,7 @@ export const MockObject = `
     date: MockDate!
     finance: MockFinance!
     Float: Float!
+    hacker: MockHacker!
     ID(value: String): ID!
     Int: Int!
     List(length: Int = 0): [MockObject]!
@@ -114,6 +126,7 @@ export const typeDefs = [
   MockDatabase,
   MockDate,
   MockFinance,
+  MockHacker,
   MockObject,
   Query,
 ]

--- a/packages/graphql-mock-object/typeDefs/index.js
+++ b/packages/graphql-mock-object/typeDefs/index.js
@@ -46,12 +46,22 @@ export const MockCompany = `
   }
 `
 
+export const MockDatabase = `
+  type MockDatabase {
+    collation: String!
+    column: String!
+    engine: String!
+    type: String!
+  }
+`
+
 export const MockObject = `
   type MockObject {
     address: MockAddress!
+    Boolean: Boolean!
     commerce: MockCommerce!
     company: MockCompany!
-    Boolean: Boolean!
+    database: MockDatabase!
     Float: Float!
     ID(value: String): ID!
     Int: Int!
@@ -72,6 +82,7 @@ export const typeDefs = [
   MockAddress,
   MockCommerce,
   MockCompany,
+  MockDatabase,
   MockObject,
   Query,
 ]

--- a/packages/graphql-mock-object/typeDefs/index.js
+++ b/packages/graphql-mock-object/typeDefs/index.js
@@ -55,6 +55,17 @@ export const MockDatabase = `
   }
 `
 
+export const MockDate = `
+  type MockDate {
+    between(from: String!, to: String!): String!
+    future(refDate: String, years: Int): String!
+    month: String!
+    past(refDate: String, years: Int): String!
+    recent(days: Int): String!
+    weekday: String!
+  }
+`
+
 export const MockObject = `
   type MockObject {
     address: MockAddress!
@@ -62,6 +73,7 @@ export const MockObject = `
     commerce: MockCommerce!
     company: MockCompany!
     database: MockDatabase!
+    date: MockDate
     Float: Float!
     ID(value: String): ID!
     Int: Int!
@@ -83,6 +95,7 @@ export const typeDefs = [
   MockCommerce,
   MockCompany,
   MockDatabase,
+  MockDate,
   MockObject,
   Query,
 ]

--- a/packages/graphql-mock-object/typeDefs/index.js
+++ b/packages/graphql-mock-object/typeDefs/index.js
@@ -1,11 +1,30 @@
 export const MockObject = `
+  type MockAddress {
+    city: String!
+    cityPrefix: String!
+    country: String!
+    countryCode: String!
+    county: String!
+    latitude: Float!
+    longitude: Float!
+    secondaryAddress: String!
+    state: String!
+    stateAbbr: String!
+    streetAddress: String!
+    streetName: String!
+    streetPrefix: String!
+    streetSuffix: String!
+    zipCode: String!
+  }
+
   type MockObject {
+    address: MockAddress!
     Boolean: Boolean!
     Float: Float!
     ID(value: String): ID!
     Int: Int!
     List(length: Int = 0): [MockObject]!
-    Mock(seed: Int): MockObject
+    Mock(seed: Int): MockObject!
     Null: String
     String(value: String): String!
   }

--- a/packages/graphql-mock-object/typeDefs/index.js
+++ b/packages/graphql-mock-object/typeDefs/index.js
@@ -184,7 +184,16 @@ export const MockObject = `
     Mock(seed: Int): MockObject!
     name: MockName!
     Null: String
+    phone: MockPhone!
     String(value: String): String!
+  }
+`
+
+export const MockPhone = `
+  type MockPhone {
+    phoneFormats: String!
+    phoneNumber: String!
+    phoneNumberFormat: String!
   }
 `
 
@@ -207,5 +216,6 @@ export const typeDefs = [
   MockLorem,
   MockName,
   MockObject,
+  MockPhone,
   Query,
 ]

--- a/packages/graphql-mock-object/typeDefs/index.js
+++ b/packages/graphql-mock-object/typeDefs/index.js
@@ -93,6 +93,28 @@ export const MockHacker = `
   }
 `
 
+export const MockImage = `
+  type MockImage {
+    abstract(width: Int, height: Int, random: Boolean): String!
+    animals(width: Int, height: Int, random: Boolean): String!
+    avatar: String!
+    business(width: Int, height: Int, random: Boolean): String!
+    cats(width: Int, height: Int, random: Boolean): String!
+    city(width: Int, height: Int, random: Boolean): String!
+    dataUri(width: Int, height: Int): String!
+    fashion(width: Int, height: Int, random: Boolean): String!
+    food(width: Int, height: Int, random: Boolean): String!
+    image(width: Int, height: Int, random: Boolean): String!
+    imageUrl(width: Int, height: Int, random: Boolean): String!
+    nature(width: Int, height: Int, random: Boolean): String!
+    nightlife(width: Int, height: Int, random: Boolean): String!
+    people(width: Int, height: Int, random: Boolean): String!
+    sports(width: Int, height: Int, random: Boolean): String!
+    technics(width: Int, height: Int, random: Boolean): String!
+    transport(width: Int, height: Int, random: Boolean): String!
+  }
+`
+
 export const MockObject = `
   type MockObject {
     address: MockAddress!
@@ -105,6 +127,7 @@ export const MockObject = `
     Float: Float!
     hacker: MockHacker!
     ID(value: String): ID!
+    image: MockImage!
     Int: Int!
     List(length: Int = 0): [MockObject]!
     Mock(seed: Int): MockObject!
@@ -127,6 +150,7 @@ export const typeDefs = [
   MockDate,
   MockFinance,
   MockHacker,
+  MockImage,
   MockObject,
   Query,
 ]

--- a/packages/graphql-mock-object/typeDefs/index.js
+++ b/packages/graphql-mock-object/typeDefs/index.js
@@ -185,6 +185,7 @@ export const MockObject = `
     name: MockName!
     Null: String
     phone: MockPhone!
+    random: MockRandom!
     String(value: String): String!
   }
 `
@@ -194,6 +195,21 @@ export const MockPhone = `
     phoneFormats: String!
     phoneNumber: String!
     phoneNumberFormat: String!
+  }
+`
+
+export const MockRandom = `
+  type MockRandom {
+    alphaNumeric: String!
+    arrayElement: String!
+    boolean: Boolean!
+    image: String!
+    locale: String!
+    number: Int!
+    objectElement: String!
+    uuid: String!
+    word: String!
+    words: String!
   }
 `
 
@@ -217,5 +233,6 @@ export const typeDefs = [
   MockName,
   MockObject,
   MockPhone,
+  MockRandom,
   Query,
 ]

--- a/packages/graphql-mock-object/typeDefs/index.js
+++ b/packages/graphql-mock-object/typeDefs/index.js
@@ -115,6 +115,26 @@ export const MockImage = `
   }
 `
 
+export const MockInternet = `
+  type MockInternet {
+    avatar: String!
+    color: String!
+    domainName: String!
+    domainSuffix: String!
+    domainWord: String!
+    email: String!
+    exampleEmail: String!
+    ip: String!
+    ipv6: String!
+    mac: String!
+    password: String!
+    protocol: String!
+    url: String!
+    userAgent: String!
+    userName: String!
+  }
+`
+
 export const MockObject = `
   type MockObject {
     address: MockAddress!
@@ -129,6 +149,7 @@ export const MockObject = `
     ID(value: String): ID!
     image: MockImage!
     Int: Int!
+    internet: MockInternet!
     List(length: Int = 0): [MockObject]!
     Mock(seed: Int): MockObject!
     Null: String
@@ -151,6 +172,7 @@ export const typeDefs = [
   MockFinance,
   MockHacker,
   MockImage,
+  MockInternet,
   MockObject,
   Query,
 ]

--- a/packages/graphql-mock-object/typeDefs/index.js
+++ b/packages/graphql-mock-object/typeDefs/index.js
@@ -1,4 +1,4 @@
-export const MockObject = `
+export const MockAddress = `
   type MockAddress {
     city: String!
     cityPrefix: String!
@@ -16,9 +16,23 @@ export const MockObject = `
     streetSuffix: String!
     zipCode: String!
   }
+`
 
+export const MockCommerce = `
+  type MockCommerce {
+    color: String!
+    department: String!
+    price: Float!
+    product: String!
+    productAdjective: String!
+    productName: String!
+    productMaterial: String!
+  }
+`
+export const MockObject = `
   type MockObject {
     address: MockAddress!
+    commerce: MockCommerce!
     Boolean: Boolean!
     Float: Float!
     ID(value: String): ID!
@@ -36,4 +50,4 @@ export const Query = `
   }
 `
 
-export const typeDefs = [MockObject, Query]
+export const typeDefs = [MockAddress, MockCommerce, MockObject, Query]

--- a/packages/graphql-mock-object/typeDefs/index.js
+++ b/packages/graphql-mock-object/typeDefs/index.js
@@ -149,6 +149,21 @@ export const MockLorem = `
   }
 `
 
+export const MockName = `
+  type MockName {
+    findName: String!
+    firstName: String!
+    jobArea: String!
+    jobDescriptor: String!
+    jobTitle: String!
+    jobType: String!
+    lastName: String!
+    prefix: String!
+    suffix: String!
+    title: String!
+  }
+`
+
 export const MockObject = `
   type MockObject {
     address: MockAddress!
@@ -167,6 +182,7 @@ export const MockObject = `
     List(length: Int = 0): [MockObject]!
     lorem: MockLorem!
     Mock(seed: Int): MockObject!
+    name: MockName!
     Null: String
     String(value: String): String!
   }
@@ -189,6 +205,7 @@ export const typeDefs = [
   MockImage,
   MockInternet,
   MockLorem,
+  MockName,
   MockObject,
   Query,
 ]

--- a/packages/graphql-mock-object/typeDefs/index.spec.js
+++ b/packages/graphql-mock-object/typeDefs/index.spec.js
@@ -221,6 +221,19 @@ describe("typeDefs", () => {
             word
             words
           }
+
+          name {
+            findName
+            firstName
+            jobArea
+            jobDescriptor
+            jobTitle
+            jobType
+            lastName
+            prefix
+            suffix
+            title
+          }
         }
       }`
 

--- a/packages/graphql-mock-object/typeDefs/index.spec.js
+++ b/packages/graphql-mock-object/typeDefs/index.spec.js
@@ -190,6 +190,24 @@ describe("typeDefs", () => {
             technics
             transport
           }
+
+          internet {
+            avatar
+            color
+            domainName
+            domainSuffix
+            domainWord
+            email
+            exampleEmail
+            ip
+            ipv6
+            mac
+            password
+            protocol
+            url
+            userAgent
+            userName
+          }
         }
       }`
 

--- a/packages/graphql-mock-object/typeDefs/index.spec.js
+++ b/packages/graphql-mock-object/typeDefs/index.spec.js
@@ -147,6 +147,20 @@ describe("typeDefs", () => {
             recent
             weekday
           }
+
+          finance {
+            account
+            accountName
+            amount
+            bic
+            bitcoinAddress
+            currencyCode
+            currencyName
+            currencySymbol
+            iban
+            mask
+            transactionType
+          }
         }
       }`
 

--- a/packages/graphql-mock-object/typeDefs/index.spec.js
+++ b/packages/graphql-mock-object/typeDefs/index.spec.js
@@ -94,6 +94,16 @@ describe("typeDefs", () => {
             streetSuffix
             zipCode
           }
+
+          commerce {
+            color
+            department
+            price
+            product
+            productAdjective
+            productMaterial
+            productName
+          }
         }
       }`
 

--- a/packages/graphql-mock-object/typeDefs/index.spec.js
+++ b/packages/graphql-mock-object/typeDefs/index.spec.js
@@ -75,6 +75,16 @@ describe("typeDefs", () => {
     })
 
     it("should support faker.js", async () => {
+      const date = new Date("Mon, 01 Jan 2018 08:00:00 GMT")
+
+      global.Date = class extends Date {
+        constructor() {
+          super()
+
+          return date
+        }
+      }
+
       const query = `{
         Mock {
           address {
@@ -124,6 +134,18 @@ describe("typeDefs", () => {
             column
             engine
             type
+          }
+
+          date {
+            between(
+              from: "Mon, 01 Jan 2018 08:00:00 GMT"
+              to: "Tues, 01 Jan 2019 08:00:00 GMT"
+            )
+            future
+            month
+            past
+            recent
+            weekday
           }
         }
       }`

--- a/packages/graphql-mock-object/typeDefs/index.spec.js
+++ b/packages/graphql-mock-object/typeDefs/index.spec.js
@@ -161,6 +161,15 @@ describe("typeDefs", () => {
             mask
             transactionType
           }
+
+          hacker {
+            abbreviation
+            adjective
+            ingverb
+            noun
+            phrase
+            verb
+          }
         }
       }`
 

--- a/packages/graphql-mock-object/typeDefs/index.spec.js
+++ b/packages/graphql-mock-object/typeDefs/index.spec.js
@@ -240,6 +240,19 @@ describe("typeDefs", () => {
             phoneNumber
             phoneNumberFormat
           }
+
+          random {
+            alphaNumeric
+            arrayElement
+            boolean
+            image
+            locale
+            number
+            objectElement
+            uuid
+            word
+            words
+          }
         }
       }`
 

--- a/packages/graphql-mock-object/typeDefs/index.spec.js
+++ b/packages/graphql-mock-object/typeDefs/index.spec.js
@@ -73,5 +73,34 @@ describe("typeDefs", () => {
 
       expect(duplicate.data).toEqual(data)
     })
+
+    it("should support faker.js", async () => {
+      const query = `{
+        Mock {
+          address {
+            city
+            cityPrefix
+            country
+            countryCode
+            county
+            latitude
+            longitude
+            secondaryAddress
+            state
+            stateAbbr
+            streetAddress
+            streetName
+            streetPrefix
+            streetSuffix
+            zipCode
+          }
+        }
+      }`
+
+      const { data, errors } = await runQuery({ query, schema })
+
+      expect(errors).toBeUndefined()
+      expect(data).toMatchSnapshot()
+    })
   })
 })

--- a/packages/graphql-mock-object/typeDefs/index.spec.js
+++ b/packages/graphql-mock-object/typeDefs/index.spec.js
@@ -118,6 +118,13 @@ describe("typeDefs", () => {
             companySuffix
             suffixes
           }
+
+          database {
+            collation
+            column
+            engine
+            type
+          }
         }
       }`
 

--- a/packages/graphql-mock-object/typeDefs/index.spec.js
+++ b/packages/graphql-mock-object/typeDefs/index.spec.js
@@ -234,6 +234,12 @@ describe("typeDefs", () => {
             suffix
             title
           }
+
+          phone {
+            phoneFormats
+            phoneNumber
+            phoneNumberFormat
+          }
         }
       }`
 

--- a/packages/graphql-mock-object/typeDefs/index.spec.js
+++ b/packages/graphql-mock-object/typeDefs/index.spec.js
@@ -209,6 +209,18 @@ describe("typeDefs", () => {
             # userAgent
             userName
           }
+
+          lorem {
+            lines
+            paragraph
+            paragraphs
+            sentence
+            sentences
+            slug
+            text
+            word
+            words
+          }
         }
       }`
 

--- a/packages/graphql-mock-object/typeDefs/index.spec.js
+++ b/packages/graphql-mock-object/typeDefs/index.spec.js
@@ -253,6 +253,17 @@ describe("typeDefs", () => {
             word
             words
           }
+
+          system {
+            commonFileExt
+            commonFileName
+            commonFileType
+            fileExt
+            fileName
+            fileType
+            mimeType
+            semver
+          }
         }
       }`
 

--- a/packages/graphql-mock-object/typeDefs/index.spec.js
+++ b/packages/graphql-mock-object/typeDefs/index.spec.js
@@ -170,6 +170,26 @@ describe("typeDefs", () => {
             phrase
             verb
           }
+
+          image {
+            abstract
+            animals
+            avatar
+            business
+            cats
+            city
+            dataUri
+            fashion
+            food
+            image
+            imageUrl
+            nature
+            nightlife
+            people
+            sports
+            technics
+            transport
+          }
         }
       }`
 

--- a/packages/graphql-mock-object/typeDefs/index.spec.js
+++ b/packages/graphql-mock-object/typeDefs/index.spec.js
@@ -205,7 +205,8 @@ describe("typeDefs", () => {
             password
             protocol
             url
-            userAgent
+            # ! Does not respect seed: https://github.com/Marak/faker.js/issues/521
+            # userAgent
             userName
           }
         }

--- a/packages/graphql-mock-object/typeDefs/index.spec.js
+++ b/packages/graphql-mock-object/typeDefs/index.spec.js
@@ -104,6 +104,20 @@ describe("typeDefs", () => {
             productMaterial
             productName
           }
+
+          company {
+            bs
+            bsAdjective
+            bsBuzz
+            bsNoun
+            catchPhraseAdjective
+            catchPhraseDescriptor
+            catchPhrase
+            catchPhraseNoun
+            companyName
+            companySuffix
+            suffixes
+          }
         }
       }`
 


### PR DESCRIPTION
See examples values here:
> https://rawgit.com/Marak/faker.js/master/examples/browser/index.html#internet

See example definitions here:
> https://github.com/APIs-guru/graphql-faker/blob/master/src/fake_definition.graphql

I'd like to see something like:

```gql
{
  repo: Mock {
    id: randomNumber
    description: companyBS
  }
}
```

This is basically a short-cut for:

```gql
{
  repo: Mock {
    id: ID(value: "{{random.number}}")
    description: String(value: "{{company.bs}}")
  }
}
```